### PR TITLE
Allow rvdb to receive characters from the Otter over serial

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,4 +5,4 @@ rvdb_SOURCES = \
     cli.c cli.h data.c data.h \
     debug.c debug.h file_io.c file_io.h \
     main.c serial.c serial.h types.h \
-    util.c util.h
+    util.c util.h pollLib.c pollLib.h

--- a/src/cli.h
+++ b/src/cli.h
@@ -12,6 +12,10 @@
 #define MAX_BREAK_PTS 8
 #define MAX_VAR_COUNT 256
 
+#define MAX_RECEIVE_LEN 1024
+
+#define MAX_INPUT_LEN 1024
+
 #define REL_CONFIG_PATH "/.config/rvdb/config"
 
 #define CTEST_TOKEN "t"

--- a/src/pollLib.c
+++ b/src/pollLib.c
@@ -1,0 +1,119 @@
+//
+// Written Hugh Smith, Updated: April 2020
+// Use at your own risk.  Feel free to copy, just leave my name in it.
+//
+
+#include <poll.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "pollLib.h"
+
+
+// Poll global variables 
+static struct pollfd * pollFileDescriptors;
+static int maxFileDescriptor = 0;
+static int currentPollSetSize = 0;
+
+static void growPollSet(int newSetSize);
+
+// Poll functions (setup, add, remove, call)
+void setupPollSet()
+{
+	currentPollSetSize = POLL_SET_SIZE;
+	pollFileDescriptors = (struct pollfd *) calloc(POLL_SET_SIZE, sizeof(struct pollfd));
+}
+
+
+void addToPollSet(int socketNumber)
+{
+	
+	if (socketNumber >= currentPollSetSize)
+	{
+		// needs to increase off of the biggest socket number since
+		// the file desc. may grow with files open or sockets
+		// so socketNumber could be much bigger than currentPollSetSize
+		growPollSet(socketNumber + POLL_SET_SIZE);		
+	}
+	
+	if (socketNumber + 1 >= maxFileDescriptor)
+	{
+		maxFileDescriptor = socketNumber + 1;
+	}
+
+	pollFileDescriptors[socketNumber].fd = socketNumber;
+	pollFileDescriptors[socketNumber].events = POLLIN;
+}
+
+void removeFromPollSet(int socketNumber)
+{
+	pollFileDescriptors[socketNumber].fd = 0;
+	pollFileDescriptors[socketNumber].events = 0;
+}
+
+int pollCall(int timeInMilliSeconds)
+{
+	// returns the socket number if one is ready for read
+	// returns -1 if timeout occurred
+	// if timeInMilliSeconds == -1 blocks forever (until a socket ready)
+	// (this -1 is a feature of poll)
+	
+	int i = 0;
+	int returnValue = -1;
+	int pollValue = 0;
+	
+	if ((pollValue = poll(pollFileDescriptors, maxFileDescriptor, timeInMilliSeconds)) < 0)
+	{
+		perror("pollCall");
+		exit(-1);
+	}	
+			
+	// check to see if timeout occurred (poll returned 0)
+	if (pollValue > 0)
+	{
+		// see which socket is ready
+		for (i = 0; i < maxFileDescriptor; i++)
+		{
+			//if(pollFileDescriptors[i].revents & (POLLIN|POLLHUP|POLLNVAL)) 
+			//Could just check for some revents, but want to catch any of them
+			//Otherwise, this could mask an error (eat the error condition)
+			if(pollFileDescriptors[i].revents > 0) 
+			{
+				//printf("for socket %d poll revents: %d\n", i, pollFileDescriptors[i].revents);
+				returnValue = i;
+				break;
+			} 
+		}
+
+	}
+	
+	// Ready socket # or -1 if timeout/none
+	return returnValue;
+}
+static void growPollSet(int newSetSize)
+{
+	int i = 0;
+	
+	// just check to see if someone screwed up
+	if (newSetSize <= currentPollSetSize)
+	{
+		printf("Error - current poll set size: %d newSetSize is not greater: %d\n",
+			currentPollSetSize, newSetSize);
+		exit(-1);
+	}
+	
+	printf("Increasing poll set from: %d to %d\n", currentPollSetSize, newSetSize);
+	pollFileDescriptors = realloc(pollFileDescriptors, newSetSize * sizeof(struct pollfd));	
+	
+	// zero out the new poll set elements
+	for (i = currentPollSetSize; i < newSetSize; i++)
+	{
+		pollFileDescriptors[i].fd = 0;
+		pollFileDescriptors[i].events = 0;
+	}
+	
+	currentPollSetSize = newSetSize;
+}
+
+
+

--- a/src/pollLib.h
+++ b/src/pollLib.h
@@ -1,0 +1,21 @@
+// 
+// Writen by Hugh Smith, April 2020
+//
+// Provides an interface to the poll() library.  Allows for
+// adding a file descriptor to the set, removing one and calling poll.
+// Feel free to copy, just leave my name in it, use at your own risk.
+//
+
+
+#ifndef __POLLLIB_H__
+#define __POLLLIB_H__
+
+#define POLL_SET_SIZE 10
+#define POLL_WAIT_FOREVER -1
+
+void setupPollSet();
+void addToPollSet(int socketNumber);
+void removeFromPollSet(int socketNumber);
+int pollCall(int timeInMilliSeconds);
+
+#endif

--- a/src/serial.c
+++ b/src/serial.c
@@ -107,6 +107,23 @@ int send_word(int serial_port, word_t w) {
     return 0;
 }
 
+// read a byte from thhe device and return 0 if successful
+int recv_byte(int serial_port, byte_t *byte) {
+    ssize_t br;
+
+    br = read(serial_port, byte, 1);
+
+    if (br == -1) {
+        perror("read(serial_port)");
+        exit(-1);
+    }
+    if (br == 0) {
+        fprintf(stderr, "Error: read 0 bytes from serial_port\n");
+        return 1;
+    }
+    return 0;
+}
+
 // read a word from the device and return 0 if successful
 int recv_word(int serial_port, word_t *word) {
     word_t w;
@@ -161,4 +178,22 @@ int read_word(int serial_port, word_t *word) {
         return 0;
     }
     return 1;
+}
+
+// reads bytes from the serial port until it reaches a null terminator
+// this depends on the otter programmer sending a 0 to not get stuck, could be improved to timeout
+// returns 0 on success
+int read_string(int serial_port, char *data) {
+    int i;
+    byte_t byte;
+    i = 0;
+
+    do {
+        if (recv_byte(serial_port, &byte) != 0) {
+            return 1;
+        }
+        data[i++] = (char)byte;
+    } while(byte != '\0');
+
+    return 0;
 }

--- a/src/serial.h
+++ b/src/serial.h
@@ -21,5 +21,6 @@ typedef struct termios term_sa;
 int open_serial(char *path, int *serial_port);
 int send_word(int serial_port, word_t w);
 int read_word(int serial_port, word_t *w);
+int read_string(int serial_port, char *data);
 
 #endif


### PR DESCRIPTION
This PR allows rvdb to receive and print messages from the Otter. To print messages from the Otter, you will need to implement the [AXI mhub](https://github.com/hrinn/otter-cpu) with the serial controller that I am working on (and haven't finished yet).

In the CLI, it polls the stdin fd and the serial port fd and reacts based on which one received input. Because it hangs before the user enters input, the readline library no longer looks good. I replaced it with fgets, but that means the command history and auto completion no longer works. Because these features are gone, and since this is meant to work with a specific version of the Otter, I would recommend keeping this on a separate branch.